### PR TITLE
Add webpack's dev server to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "less-loader": "^2.2.1",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.2"
+    "webpack-dev-server": "^1.12.1"
   },
   "dependencies": {
     "blacklist": "^1.1.2",


### PR DESCRIPTION
Missing this cause makes unable to execute `npm start` command
